### PR TITLE
Add CSV export for the votes

### DIFF
--- a/pretalx_public_voting/exporters.py
+++ b/pretalx_public_voting/exporters.py
@@ -1,0 +1,37 @@
+from defusedcsv import csv
+
+from django.http import HttpResponse
+
+from .models import PublicVote
+
+
+def get_data(event):
+    fieldnames = ["code", "voter", "timestamp", "score"]
+    data = []
+    qs = PublicVote.objects.filter(
+        submission__event = event
+    ).order_by("submission__code")
+    for vote in qs:
+        data.append(
+            {
+                "code": vote.submission.code,
+                "voter": vote.email_hash,
+                "timestamp": vote.timestamp,
+                "score": vote.score,
+            }
+        )
+
+    return fieldnames, data
+
+def csv_export(request, event):
+    filename = "voting.csv"
+
+    response = HttpResponse(content_type='text/csv')
+    response['Content-Disposition'] = f'attachment; filename="{filename}"'
+
+    fieldnames, data = get_data(request.event)
+    writer = csv.DictWriter(response, fieldnames=fieldnames)
+    writer.writeheader()
+    writer.writerows(data)
+
+    return response

--- a/pretalx_public_voting/exporters.py
+++ b/pretalx_public_voting/exporters.py
@@ -1,6 +1,6 @@
 from defusedcsv import csv
 
-from django.http import HttpResponse
+from django.http import Http404, HttpResponse
 
 from .models import PublicVote
 
@@ -24,6 +24,9 @@ def get_data(event):
     return fieldnames, data
 
 def csv_export(request, event):
+    if not request.user.has_perm("orga.change_settings", request.event):
+        raise Http404()
+
     filename = "voting.csv"
 
     response = HttpResponse(content_type='text/csv')

--- a/pretalx_public_voting/urls.py
+++ b/pretalx_public_voting/urls.py
@@ -2,7 +2,7 @@ from django.urls import re_path
 
 from pretalx.event.models.event import SLUG_CHARS
 
-from . import views
+from . import views, exporters
 
 urlpatterns = [
     re_path(
@@ -24,5 +24,10 @@ urlpatterns = [
         f"^(?P<event>[{SLUG_CHARS}]+)/p/voting/talks/(?P<signed_user>[^/]+)/$",
         views.SubmissionListView.as_view(),
         name="talks",
+    ),
+    re_path(
+        f"^(?P<event>[{SLUG_CHARS}]+)/p/voting/export/$",
+        exporters.csv_export,
+        name="csv",
     ),
 ]


### PR DESCRIPTION
I've put it under `export`, if it should be under a different URL or if other formats (like e.g. JSON) should also be supported, please let me know.

I originally tried to use the Schedule export functionality, but I couldn't get it working with a plugin, hence I decided to just use a view for it.

Closes #4.