### PR TITLE
Allow session image to be hidden

### DIFF
--- a/pretalx_public_voting/forms.py
+++ b/pretalx_public_voting/forms.py
@@ -110,6 +110,12 @@ class PublicVotingSettingsForm(HierarkeyForm):
         label=_("Anonymise content"),
         help_text=_("Hide speaker names and use anonymized content where available?"),
     )
+    public_voting_show_session_image = forms.BooleanField(
+        required=False,
+        label=_("Show session image"),
+        help_text=_("Show the session image if one was uploaded."),
+        initial=True,
+    )
     public_voting_min_score = forms.IntegerField(
         label=_("Minimum score"),
         help_text=_("The minimum score voters can assign"),

--- a/pretalx_public_voting/templates/pretalx_public_voting/submission_list.html
+++ b/pretalx_public_voting/templates/pretalx_public_voting/submission_list.html
@@ -14,7 +14,7 @@
 <form method="POST" >{% csrf_token %}
     {% for submission in submissions %}
         <div class="card submission-card">
-            {% if submission.image %}
+            {% if submission.image and request.event.settings.public_voting_show_session_image %}
             <div class="card-img-top-wrapper">
             <img src="{{ submission.image.url }}" alt="{% trans "This talk's header image" %}" class="card-img-top">
             </div>


### PR DESCRIPTION
By default a session image (if available) is shown. There is now a setting
to disable session images, so that the voting page becomes more succinct.

This feature was requested by the FOSSGIS 2021 conference.