### PR TITLE
Make it possible to add custom text at the top

### DIFF
--- a/pretalx_public_voting/forms.py
+++ b/pretalx_public_voting/forms.py
@@ -1,6 +1,10 @@
 from django import forms
 from django.utils.translation import gettext_lazy as _
 from hierarkey.forms import HierarkeyForm
+from i18nfield.fields import I18nFormField, I18nTextarea
+from i18nfield.forms import I18nFormMixin
+
+from pretalx.common.phrases import phrases
 from pretalx.common.urls import build_absolute_uri
 from pretalx.mail.models import QueuedMail
 
@@ -89,8 +93,18 @@ class VoteForm(forms.Form):
         )
 
 
-class PublicVotingSettingsForm(HierarkeyForm):
+class PublicVotingSettingsForm(I18nFormMixin, HierarkeyForm):
 
+    public_voting_text = I18nFormField(
+        help_text=_(
+            "This text will be shown at the top of the public voting page."
+        )
+        + " "
+        + phrases.base.use_markdown,
+        label=_("Text"),
+        widget=I18nTextarea,
+        required=False,
+    )
     public_voting_start = forms.DateTimeField(
         help_text=_(
             "No public votes will be possible before this time. Submissions will not be publicly visible."

--- a/pretalx_public_voting/templates/pretalx_public_voting/submission_list.html
+++ b/pretalx_public_voting/templates/pretalx_public_voting/submission_list.html
@@ -10,6 +10,7 @@
 <link rel="stylesheet" href="{% static "pretalx_public_voting/vote.css" %}" />
 
 <h1>{% trans "Public voting" %}</h1>
+{{ request.event.settings.public_voting_text|rich_text }}
 {% if hashed_email %}
 <form method="POST" >{% csrf_token %}
     {% for submission in submissions %}

--- a/pretalx_public_voting/views.py
+++ b/pretalx_public_voting/views.py
@@ -133,4 +133,9 @@ class PublicVotingSettings(PermissionRequired, FormView):
 
     def get_form_kwargs(self):
         kwargs = super().get_form_kwargs()
-        return {"obj": self.request.event, "attribute_name": "settings", **kwargs}
+        return {
+            "obj": self.request.event,
+            "attribute_name": "settings",
+            "locales": self.request.event.locales,
+            **kwargs
+        }


### PR DESCRIPTION
The text of the public voting is conference specific. One might describe
in more detail what the voting options mean, or you want to give information
about how many talks will be accepted.

@rixx I tried hard, but I wasn't able to get the text field rendered correctly in the template. Currently it shows the JSON data and not the string that corresponds to the currently selected language. Any pointers would be appreciated.

This is a feature that was requested by the FOSSGIS 2021 conference.