### PR TITLE
Limit the salt to 16 bytes

### DIFF
--- a/pretalx_public_voting/utils.py
+++ b/pretalx_public_voting/utils.py
@@ -7,7 +7,7 @@ from django.core import signing
 def hash_email(email, event):
     return blake2b(
         email.encode("utf-8"),
-        salt=event.slug.encode("utf-8"),
+        salt=event.slug.encode("utf-8")[:16],
         digest_size=16,
     ).hexdigest()
 


### PR DESCRIPTION
If the slug is longer than 16 bytes, it would result in an error:

    ValueError('maximum salt length is 16 bytes')

Hence restrict it to 16 bytes.