### PR TITLE
Export voting results with more details in csv

### DIFF
--- a/pretalx_public_voting/exporters.py
+++ b/pretalx_public_voting/exporters.py
@@ -19,7 +19,7 @@ class PublicVotingCSVExporter(CSVExporterMixin, BaseExporter):
         return f"{self.event.slug}-public-votes.csv"
 
     def get_data(self, **kwargs):
-        fieldnames = ["code", "voter", "timestamp", "score"]
+        fieldnames = ["code", "voter", "timestamp", "score", "type", "track", "title"]
         data = []
         votes = (
             PublicVote.objects.filter(submission__event=self.event)
@@ -33,6 +33,9 @@ class PublicVotingCSVExporter(CSVExporterMixin, BaseExporter):
                     "voter": vote.email_hash,
                     "timestamp": vote.timestamp.isoformat(),
                     "score": vote.score,
+                    "type": vote.submission.SubmissionType,
+                    "track": vote.submission.Track,
+                    "title": vote.submission.title,
                 }
             )
 


### PR DESCRIPTION
This PR adds to the generated csv output files fields related to the title, track and type of each submission. This allows to have a comprehensive and ready-to-use CSV file. 
Fix #40