### PR TITLE
Add devcontainer specification to improve developer experience

### DIFF
--- a/.devcontainer/Containerfile
+++ b/.devcontainer/Containerfile
@@ -1,0 +1,6 @@
+FROM mcr.microsoft.com/devcontainers/python:1-3.12-bullseye
+
+RUN apt update && \
+    apt install -y libffi-dev gettext build-essential && \
+    pip3 install setuptools wheel && \
+    pip3 install --upgrade-strategy eager "pretalx[dev]"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,22 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/python
+{
+	"name": "pretalx-public-voting",
+  "build": {
+    "dockerfile": "Containerfile"
+  },  
+  "postCreateCommand": "${containerWorkspaceFolder}/.devcontainer/postCreate.sh",
+  "postStartCommand": "python3 -m pretalx runserver",
+  "containerEnv": {
+    "PRETALX_DATA_DIR": "${containerWorkspaceFolder}/.devcontainer/local"
+  },
+	"customizations": {
+    "vscode": {
+      "extensions": [
+        "ms-python.python",
+        "ms-python.debugpy"
+      ]
+    }
+  },
+  "remoteUser": "root"
+}

--- a/.devcontainer/postCreate.sh
+++ b/.devcontainer/postCreate.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+
+# Install local plugin
+python -m pip install -e .
+
+
+# Apply migrations
+python3 -m pretalx migrate

--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,6 @@ target/
 
 #Ipython Notebook
 .ipynb_checkpoints
+
+#Devcontainer
+.devcontainer/local

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,37 @@
+{
+  // See https://go.microsoft.com/fwlink/?LinkId=733558
+  // for the documentation about the tasks.json format
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "Pretalx: Initialize pretalx",
+      "icon": {
+        "color": "terminal.ansiGreen"
+      },
+      "type": "shell",
+      "command": "python3 -m pretalx init"
+    },
+    {
+      "label": "Pretalx: Create test Event",
+      "icon": {
+        "id": "book"
+      },
+      "type": "shell",
+      "command": "python3 -m pretalx create_test_event"
+    },
+    {
+      "label": "Pretalx: Start Development Server",
+      "icon": {
+        "id": "play",
+        "color": "terminal.ansiGreen"
+      },
+      "type": "shell",
+      "command": "python3 -m pretalx runserver",
+      "problemMatcher": [],
+      "group": {
+        "kind": "build",
+        "isDefault": true
+      }
+    }
+  ]
+}

--- a/README.rst
+++ b/README.rst
@@ -50,6 +50,12 @@ Initial release
 Development setup
 -----------------
 
+.. note::
+   This project contains a .devcontainer specification.
+   Use development containers to start an a read-to-use containerized development
+   environment within minutes. If you have not done already, go to https://containers.dev/supporting to learn more about
+   the local requirements and preparations to get started with your supported editor or IDEA!
+
 1. Make sure that you have a working `pretalx development setup`_.
 
 2. Clone this repository, eg to ``local/pretalx-public-voting``.


### PR DESCRIPTION
Hi,
in order to simplify the onboarding of new contributors to the project, I would like to contribute a devcontainer specification for pretalx plugins. Testing it here first before submitting it to the plugin template/other plugins.

 [Development Containers or "devcontainers"](https://containers.dev/) is an open specification mostly driven by Microsoft, allowing maintainers or contributors to easily spin up a predefined unified development environment based on common local container runtimes like podman or docker. The execution of project related preparations steps are fully automated (except for the "init" command, but this can be also automated once the necessary interface is in place.), so that the necessary steps, once podman and e.g. VS Code with the Remote Development Ext. is installed, to get started as a new contributor are reduced to:

1. Clone the project
2. Open folder in VS Code.
3. Run the "Dev Containers: Reopen in Container".

Best regards