### PR TITLE
Add copy link button to share a dedicated voting link for a submission

### DIFF
--- a/pretalx_public_voting/forms.py
+++ b/pretalx_public_voting/forms.py
@@ -16,8 +16,9 @@ class SignupForm(forms.Form):
 
     email = forms.EmailField(required=True)
 
-    def __init__(self, *args, event=None, **kwargs):
+    def __init__(self, *args, event=None, sid=None, **kwargs):
         self.event = event
+        self.sid = sid
         super().__init__(*args, **kwargs)
 
     def clean_email(self):
@@ -41,6 +42,10 @@ class SignupForm(forms.Form):
             "plugins:pretalx_public_voting:talks",
             kwargs={"event": event.slug, "signed_user": email_signed},
         )
+        
+        # Preserve 'sid' parameter if it exists
+        if self.sid:
+            vote_url += f"?sid={self.sid}"
 
         mail_text = _(
             """Hi,

--- a/pretalx_public_voting/forms.py
+++ b/pretalx_public_voting/forms.py
@@ -16,9 +16,9 @@ class SignupForm(forms.Form):
 
     email = forms.EmailField(required=True)
 
-    def __init__(self, *args, event=None, sid=None, **kwargs):
+    def __init__(self, *args, event=None, submission_code=None, **kwargs):
         self.event = event
-        self.sid = sid
+        self.submission_code = submission_code
         super().__init__(*args, **kwargs)
 
     def clean_email(self):
@@ -43,9 +43,9 @@ class SignupForm(forms.Form):
             kwargs={"event": event.slug, "signed_user": email_signed},
         )
         
-        # Preserve 'sid' parameter if it exists
-        if self.sid:
-            vote_url += f"?sid={self.sid}"
+        # Preserve 'submission_code' parameter if it exists
+        if self.submission_code:
+            vote_url += f"?submission_code={self.submission_code}"
 
         mail_text = _(
             """Hi,

--- a/pretalx_public_voting/forms.py
+++ b/pretalx_public_voting/forms.py
@@ -42,7 +42,7 @@ class SignupForm(forms.Form):
             "plugins:pretalx_public_voting:talks",
             kwargs={"event": event.slug, "signed_user": email_signed},
         )
-        
+
         # Preserve 'submission_code' parameter if it exists
         if self.submission_code:
             vote_url += f"?submission_code={self.submission_code}"

--- a/pretalx_public_voting/locale/de_DE/LC_MESSAGES/django.po
+++ b/pretalx_public_voting/locale/de_DE/LC_MESSAGES/django.po
@@ -17,23 +17,23 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.0\n"
 
-#: local/pretalx-public-voting/pretalx_public_voting/apps.py:12
+#: pretalx_public_voting/apps.py:12
 msgid "pretalx public voting plugin"
 msgstr "pretalx-Plugin für die offentliche Bewertung von Einreichungen"
 
-#: local/pretalx-public-voting/pretalx_public_voting/apps.py:14
+#: pretalx_public_voting/apps.py:14
 msgid "A public voting plugin for pretalx"
 msgstr "Ein Plugin für eine öffentliche Bewertung von Einreichungen in pretalx"
 
-#: local/pretalx-public-voting/pretalx_public_voting/exporters.py:15
+#: pretalx_public_voting/exporters.py:15
 msgid "Public Voting CSV"
 msgstr "CSV der öffentlichen Bewertungen"
 
-#: local/pretalx-public-voting/pretalx_public_voting/forms.py:29
+#: pretalx_public_voting/forms.py:30
 msgid "This address is not allowed to cast a vote."
 msgstr "Diese E-Mail-Adresse kann keine Bewertungen abgeben."
 
-#: local/pretalx-public-voting/pretalx_public_voting/forms.py:46
+#: pretalx_public_voting/forms.py:51
 #, python-brace-format
 msgid ""
 "Hi,\n"
@@ -64,27 +64,33 @@ msgstr ""
 "\n"
 "Das {event.name}-Team\n"
 
-#: local/pretalx-public-voting/pretalx_public_voting/forms.py:63
+#: pretalx_public_voting/forms.py:68
 msgid "Public voting registration"
 msgstr "Registrierung zur öffentlichen Abstimmung"
 
-#: local/pretalx-public-voting/pretalx_public_voting/forms.py:128
+#: pretalx_public_voting/forms.py:108
+#, python-brace-format
+msgid "Please assign a score between {self.min_value} and {self.max_value}!"
+msgstr ""
+"Bitte wähle eine Wertung zwischen {self.min_value} und {self.max_value}!"
+
+#: pretalx_public_voting/forms.py:133
 msgid "Score label ({})"
 msgstr "Bezeichnung ({})"
 
-#: local/pretalx-public-voting/pretalx_public_voting/forms.py:130
+#: pretalx_public_voting/forms.py:135
 msgid ""
 "Human readable explanation of what a score of \"{}\" actually means, e.g. "
 "\"great!\"."
 msgstr ""
 "Menschenlesbare Erklärung, was die Wertung \"{}\" bedeutet, z.B. \"super\"."
 
-#: local/pretalx-public-voting/pretalx_public_voting/forms.py:144
+#: pretalx_public_voting/forms.py:149
 msgid "Please assign a minimum score smaller than the maximum score!"
 msgstr ""
 "Bitte wähle eine Mindestwertung, die niedriger als die Höchstwertung ist!"
 
-#: local/pretalx-public-voting/pretalx_public_voting/models.py:22
+#: pretalx_public_voting/models.py:22
 msgid ""
 "No public votes will be possible before this time. Submissions will not be "
 "publicly visible."
@@ -92,11 +98,11 @@ msgstr ""
 "Vor diesem Zeitpunkt ist keine öffentliche Abstimmung möglich. Die "
 "Einreichungen sind dann nicht öffentlich einsehbar."
 
-#: local/pretalx-public-voting/pretalx_public_voting/models.py:24
+#: pretalx_public_voting/models.py:24
 msgid "Start"
 msgstr "Beginn"
 
-#: local/pretalx-public-voting/pretalx_public_voting/models.py:30
+#: pretalx_public_voting/models.py:30
 msgid ""
 "No public votes will be possible after this time. Submissions will not be "
 "publicly visible."
@@ -104,70 +110,70 @@ msgstr ""
 "Nach diesem Zeitpunkt ist keine öffentliche Abstimmung mehr möglich. Die "
 "Einreichungen sind dann nicht mehr öffentlich einsehbar."
 
-#: local/pretalx-public-voting/pretalx_public_voting/models.py:32
+#: pretalx_public_voting/models.py:32
 msgid "End"
 msgstr "Ende"
 
-#: local/pretalx-public-voting/pretalx_public_voting/models.py:37
+#: pretalx_public_voting/models.py:37
 msgid "Text"
 msgstr "Text"
 
-#: local/pretalx-public-voting/pretalx_public_voting/models.py:38
+#: pretalx_public_voting/models.py:38
 msgid "This text will be shown at the top of the public voting page."
 msgstr ""
 "Dieser Text wird ganz oben auf der öffentlichen Abstimmungsseite gezeigt."
 
-#: local/pretalx-public-voting/pretalx_public_voting/models.py:43
+#: pretalx_public_voting/models.py:43
 msgid "Anonymise content"
 msgstr "Text anonymisieren"
 
-#: local/pretalx-public-voting/pretalx_public_voting/models.py:44
+#: pretalx_public_voting/models.py:44
 msgid "Hide speaker names and use anonymized content where available?"
 msgstr ""
 "Namen der Vortragenden verbergen und anonymisierten Text verwenden, soweit "
 "verfügbar?"
 
-#: local/pretalx-public-voting/pretalx_public_voting/models.py:48
+#: pretalx_public_voting/models.py:48
 msgid "Show session image"
 msgstr "Bild anzeigen"
 
-#: local/pretalx-public-voting/pretalx_public_voting/models.py:49
+#: pretalx_public_voting/models.py:49
 msgid "Show the session image if one was uploaded."
 msgstr "Wenn ein Bild zum Vortrag hochgeladen wurde, dieses anzeigen."
 
-#: local/pretalx-public-voting/pretalx_public_voting/models.py:53
+#: pretalx_public_voting/models.py:53
 #, fuzzy
 #| msgid "Show session image"
 msgid "Show session description"
 msgstr "Bild anzeigen"
 
-#: local/pretalx-public-voting/pretalx_public_voting/models.py:55
+#: pretalx_public_voting/models.py:55
 msgid ""
 "By default, only the abstract of each session is listed. By enabling this, "
 "the longer description text will also be shown."
 msgstr ""
 
-#: local/pretalx-public-voting/pretalx_public_voting/models.py:61
+#: pretalx_public_voting/models.py:61
 msgid "Minimum score"
 msgstr "Mindestwertung"
 
-#: local/pretalx-public-voting/pretalx_public_voting/models.py:62
+#: pretalx_public_voting/models.py:62
 msgid "The minimum score voters can assign"
 msgstr "Die geringste Wertung, die vergeben werden kann"
 
-#: local/pretalx-public-voting/pretalx_public_voting/models.py:66
+#: pretalx_public_voting/models.py:66
 msgid "Maximum score"
 msgstr "Höchstwertung"
 
-#: local/pretalx-public-voting/pretalx_public_voting/models.py:67
+#: pretalx_public_voting/models.py:67
 msgid "The maximum score voters can assign"
 msgstr "Die höchte Wertung, die vergeben werden kann"
 
-#: local/pretalx-public-voting/pretalx_public_voting/models.py:73
+#: pretalx_public_voting/models.py:73
 msgid "Allowed emails"
 msgstr "Erlaubte E-Mail-Adressen"
 
-#: local/pretalx-public-voting/pretalx_public_voting/models.py:75
+#: pretalx_public_voting/models.py:75
 msgid ""
 "You can limit who is allowed to cast a vote. Please enter one email address "
 "per line."
@@ -175,41 +181,41 @@ msgstr ""
 "Du kannst beschränken, wer eine Bewertung abgeben darf. Bitte gib eine "
 "Adresse pro Zeile ein."
 
-#: local/pretalx-public-voting/pretalx_public_voting/models.py:79
+#: pretalx_public_voting/models.py:79
 msgid "Limit to tracks"
 msgstr ""
 
-#: local/pretalx-public-voting/pretalx_public_voting/models.py:83
+#: pretalx_public_voting/models.py:83
 msgid "Limit to session types"
 msgstr ""
 
-#: local/pretalx-public-voting/pretalx_public_voting/models.py:85
+#: pretalx_public_voting/models.py:85
 msgid "If no session type is selected, then all submissions are shown."
 msgstr ""
 
-#: local/pretalx-public-voting/pretalx_public_voting/models.py:97
-#: local/pretalx-public-voting/pretalx_public_voting/templates/pretalx_public_voting/submission_list.html:48
+#: pretalx_public_voting/models.py:97
+#: pretalx_public_voting/templates/pretalx_public_voting/submission_list.html:62
 msgid "Score"
 msgstr "Wertung"
 
-#: local/pretalx-public-voting/pretalx_public_voting/signals.py:14
-#: local/pretalx-public-voting/pretalx_public_voting/templates/pretalx_public_voting/submission_list.html:23
+#: pretalx_public_voting/signals.py:14
+#: pretalx_public_voting/templates/pretalx_public_voting/submission_list.html:24
 msgid "Public voting"
 msgstr "Öffentliche Abstimmung"
 
-#: local/pretalx-public-voting/pretalx_public_voting/templates/pretalx_public_voting/settings.html:8
+#: pretalx_public_voting/templates/pretalx_public_voting/settings.html:8
 msgid "Set up public voting"
 msgstr "Öffentliche Abstimmung einrichten"
 
-#: local/pretalx-public-voting/pretalx_public_voting/templates/pretalx_public_voting/settings.html:11
+#: pretalx_public_voting/templates/pretalx_public_voting/settings.html:11
 msgid "Download results CSV"
 msgstr ""
 
-#: local/pretalx-public-voting/pretalx_public_voting/templates/pretalx_public_voting/settings.html:14
+#: pretalx_public_voting/templates/pretalx_public_voting/settings.html:14
 msgid "Go to public voting"
 msgstr "Zur öffentlichen Abstimmung"
 
-#: local/pretalx-public-voting/pretalx_public_voting/templates/pretalx_public_voting/settings.html:19
+#: pretalx_public_voting/templates/pretalx_public_voting/settings.html:19
 msgid ""
 "Public voting will show your submissions publicly, and will allow anybody "
 "who provides a valid email address to vote. The email addresses are not "
@@ -219,11 +225,11 @@ msgstr ""
 "ermöglicht es jedem, der eine gültige E-Mail-Adresse hat, abzustimmen. E-"
 "Mail-Adressen werden nicht gespeichert. Die Abstimmung ist also anonym."
 
-#: local/pretalx-public-voting/pretalx_public_voting/templates/pretalx_public_voting/signup.html:6
+#: pretalx_public_voting/templates/pretalx_public_voting/signup.html:6
 msgid "Public voting signup"
 msgstr "Anmeldung zur öffentlichen Abstimmung"
 
-#: local/pretalx-public-voting/pretalx_public_voting/templates/pretalx_public_voting/signup.html:8
+#: pretalx_public_voting/templates/pretalx_public_voting/signup.html:8
 msgid ""
 "Welcome to the voting process for this event! Voting is open to the public, "
 "and we just need to confirm your email address first. You will only need to "
@@ -233,7 +239,7 @@ msgstr ""
 "Veranstaltung! Die Stimmabgabe steht jedem offen, wir brauchen nur deine E-"
 "Mail-Adresse."
 
-#: local/pretalx-public-voting/pretalx_public_voting/templates/pretalx_public_voting/signup.html:15
+#: pretalx_public_voting/templates/pretalx_public_voting/signup.html:15
 msgid ""
 "Please note that we do <strong>not</strong> store your email address, and "
 "all votes will be completely anonymous."
@@ -241,15 +247,27 @@ msgstr ""
 "Bitte beachte, dass wir deine E-Mail-Adresse <strong>nicht</strong> "
 "speichern und dass die Stimmabgabe vollständig anonym ist."
 
-#: local/pretalx-public-voting/pretalx_public_voting/templates/pretalx_public_voting/submission_list.html:32
+#: pretalx_public_voting/templates/pretalx_public_voting/submission_list.html:29
+msgid "A filter is active. Only limited subset of all submission is shown."
+msgstr "Filter aktiv. Nur eine Auswahl an Abstimmungen werden angezeigt."
+
+#: pretalx_public_voting/templates/pretalx_public_voting/submission_list.html:30
+msgid "Click here to reset."
+msgstr "Klicke hier zum Zurücksetzten."
+
+#: pretalx_public_voting/templates/pretalx_public_voting/submission_list.html:41
 msgid "This talk's header image"
 msgstr "Das Titelbild des Vortags"
 
-#: local/pretalx-public-voting/pretalx_public_voting/templates/pretalx_public_voting/submission_list.html:66
+#: pretalx_public_voting/templates/pretalx_public_voting/submission_list.html:47
+msgid "Copied!"
+msgstr "Kopiert!"
+
+#: pretalx_public_voting/templates/pretalx_public_voting/submission_list.html:80
 msgid "Save!"
 msgstr "Speichern!"
 
-#: local/pretalx-public-voting/pretalx_public_voting/templates/pretalx_public_voting/submission_list.html:72
+#: pretalx_public_voting/templates/pretalx_public_voting/submission_list.html:86
 msgid ""
 "This page is invalid. Please double-check that you have followed a complete "
 "link to this place."
@@ -257,15 +275,15 @@ msgstr ""
 "Diese Seite ist nicht zulässig. Bitte vergewissere dich, dass du den "
 "gesamten Link verwendet hast."
 
-#: local/pretalx-public-voting/pretalx_public_voting/templates/pretalx_public_voting/submission_list.html:75
+#: pretalx_public_voting/templates/pretalx_public_voting/submission_list.html:89
 msgid "Click here to sign up for voting."
 msgstr "Bitte klicke hier, um dich für die öffentliche Abstimmung anzumelden."
 
-#: local/pretalx-public-voting/pretalx_public_voting/templates/pretalx_public_voting/thanks.html:5
+#: pretalx_public_voting/templates/pretalx_public_voting/thanks.html:5
 msgid "Thanks for signing up!"
 msgstr "Vielen Dank für deine Anmeldung!"
 
-#: local/pretalx-public-voting/pretalx_public_voting/templates/pretalx_public_voting/thanks.html:7
+#: pretalx_public_voting/templates/pretalx_public_voting/thanks.html:7
 msgid ""
 "Thanks for signing up for public voting. You've received an email with your "
 "personal link to the vote. If you don't see an email within five minutes, "
@@ -279,11 +297,6 @@ msgstr ""
 #: local/pretalx-public-voting/pretalx_public_voting/views.py:148
 msgid "Thank you for your vote!"
 msgstr "Vielen Dank für deine Stimmabgabe!"
-
-#, python-brace-format
-#~ msgid "Please assign a score between {self.min_value} and {self.max_value}!"
-#~ msgstr ""
-#~ "Bitte wähle eine Wertung zwischen {self.min_value} und {self.max_value}!"
 
 #~ msgid "Save"
 #~ msgstr "Speichern"

--- a/pretalx_public_voting/locale/de_DE/LC_MESSAGES/django.po
+++ b/pretalx_public_voting/locale/de_DE/LC_MESSAGES/django.po
@@ -17,23 +17,23 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.0\n"
 
-#: pretalx_public_voting/apps.py:12
+#: local/pretalx-public-voting/pretalx_public_voting/apps.py:12
 msgid "pretalx public voting plugin"
 msgstr "pretalx-Plugin für die offentliche Bewertung von Einreichungen"
 
-#: pretalx_public_voting/apps.py:14
+#: local/pretalx-public-voting/pretalx_public_voting/apps.py:14
 msgid "A public voting plugin for pretalx"
 msgstr "Ein Plugin für eine öffentliche Bewertung von Einreichungen in pretalx"
 
-#: pretalx_public_voting/exporters.py:15
+#: local/pretalx-public-voting/pretalx_public_voting/exporters.py:15
 msgid "Public Voting CSV"
 msgstr "CSV der öffentlichen Bewertungen"
 
-#: pretalx_public_voting/forms.py:30
+#: local/pretalx-public-voting/pretalx_public_voting/forms.py:29
 msgid "This address is not allowed to cast a vote."
 msgstr "Diese E-Mail-Adresse kann keine Bewertungen abgeben."
 
-#: pretalx_public_voting/forms.py:51
+#: local/pretalx-public-voting/pretalx_public_voting/forms.py:46
 #, python-brace-format
 msgid ""
 "Hi,\n"
@@ -64,33 +64,27 @@ msgstr ""
 "\n"
 "Das {event.name}-Team\n"
 
-#: pretalx_public_voting/forms.py:68
+#: local/pretalx-public-voting/pretalx_public_voting/forms.py:63
 msgid "Public voting registration"
 msgstr "Registrierung zur öffentlichen Abstimmung"
 
-#: pretalx_public_voting/forms.py:108
-#, python-brace-format
-msgid "Please assign a score between {self.min_value} and {self.max_value}!"
-msgstr ""
-"Bitte wähle eine Wertung zwischen {self.min_value} und {self.max_value}!"
-
-#: pretalx_public_voting/forms.py:133
+#: local/pretalx-public-voting/pretalx_public_voting/forms.py:128
 msgid "Score label ({})"
 msgstr "Bezeichnung ({})"
 
-#: pretalx_public_voting/forms.py:135
+#: local/pretalx-public-voting/pretalx_public_voting/forms.py:130
 msgid ""
 "Human readable explanation of what a score of \"{}\" actually means, e.g. "
 "\"great!\"."
 msgstr ""
 "Menschenlesbare Erklärung, was die Wertung \"{}\" bedeutet, z.B. \"super\"."
 
-#: pretalx_public_voting/forms.py:149
+#: local/pretalx-public-voting/pretalx_public_voting/forms.py:144
 msgid "Please assign a minimum score smaller than the maximum score!"
 msgstr ""
 "Bitte wähle eine Mindestwertung, die niedriger als die Höchstwertung ist!"
 
-#: pretalx_public_voting/models.py:22
+#: local/pretalx-public-voting/pretalx_public_voting/models.py:22
 msgid ""
 "No public votes will be possible before this time. Submissions will not be "
 "publicly visible."
@@ -98,11 +92,11 @@ msgstr ""
 "Vor diesem Zeitpunkt ist keine öffentliche Abstimmung möglich. Die "
 "Einreichungen sind dann nicht öffentlich einsehbar."
 
-#: pretalx_public_voting/models.py:24
+#: local/pretalx-public-voting/pretalx_public_voting/models.py:24
 msgid "Start"
 msgstr "Beginn"
 
-#: pretalx_public_voting/models.py:30
+#: local/pretalx-public-voting/pretalx_public_voting/models.py:30
 msgid ""
 "No public votes will be possible after this time. Submissions will not be "
 "publicly visible."
@@ -110,70 +104,70 @@ msgstr ""
 "Nach diesem Zeitpunkt ist keine öffentliche Abstimmung mehr möglich. Die "
 "Einreichungen sind dann nicht mehr öffentlich einsehbar."
 
-#: pretalx_public_voting/models.py:32
+#: local/pretalx-public-voting/pretalx_public_voting/models.py:32
 msgid "End"
 msgstr "Ende"
 
-#: pretalx_public_voting/models.py:37
+#: local/pretalx-public-voting/pretalx_public_voting/models.py:37
 msgid "Text"
 msgstr "Text"
 
-#: pretalx_public_voting/models.py:38
+#: local/pretalx-public-voting/pretalx_public_voting/models.py:38
 msgid "This text will be shown at the top of the public voting page."
 msgstr ""
 "Dieser Text wird ganz oben auf der öffentlichen Abstimmungsseite gezeigt."
 
-#: pretalx_public_voting/models.py:43
+#: local/pretalx-public-voting/pretalx_public_voting/models.py:43
 msgid "Anonymise content"
 msgstr "Text anonymisieren"
 
-#: pretalx_public_voting/models.py:44
+#: local/pretalx-public-voting/pretalx_public_voting/models.py:44
 msgid "Hide speaker names and use anonymized content where available?"
 msgstr ""
 "Namen der Vortragenden verbergen und anonymisierten Text verwenden, soweit "
 "verfügbar?"
 
-#: pretalx_public_voting/models.py:48
+#: local/pretalx-public-voting/pretalx_public_voting/models.py:48
 msgid "Show session image"
 msgstr "Bild anzeigen"
 
-#: pretalx_public_voting/models.py:49
+#: local/pretalx-public-voting/pretalx_public_voting/models.py:49
 msgid "Show the session image if one was uploaded."
 msgstr "Wenn ein Bild zum Vortrag hochgeladen wurde, dieses anzeigen."
 
-#: pretalx_public_voting/models.py:53
+#: local/pretalx-public-voting/pretalx_public_voting/models.py:53
 #, fuzzy
 #| msgid "Show session image"
 msgid "Show session description"
 msgstr "Bild anzeigen"
 
-#: pretalx_public_voting/models.py:55
+#: local/pretalx-public-voting/pretalx_public_voting/models.py:55
 msgid ""
 "By default, only the abstract of each session is listed. By enabling this, "
 "the longer description text will also be shown."
 msgstr ""
 
-#: pretalx_public_voting/models.py:61
+#: local/pretalx-public-voting/pretalx_public_voting/models.py:61
 msgid "Minimum score"
 msgstr "Mindestwertung"
 
-#: pretalx_public_voting/models.py:62
+#: local/pretalx-public-voting/pretalx_public_voting/models.py:62
 msgid "The minimum score voters can assign"
 msgstr "Die geringste Wertung, die vergeben werden kann"
 
-#: pretalx_public_voting/models.py:66
+#: local/pretalx-public-voting/pretalx_public_voting/models.py:66
 msgid "Maximum score"
 msgstr "Höchstwertung"
 
-#: pretalx_public_voting/models.py:67
+#: local/pretalx-public-voting/pretalx_public_voting/models.py:67
 msgid "The maximum score voters can assign"
 msgstr "Die höchte Wertung, die vergeben werden kann"
 
-#: pretalx_public_voting/models.py:73
+#: local/pretalx-public-voting/pretalx_public_voting/models.py:73
 msgid "Allowed emails"
 msgstr "Erlaubte E-Mail-Adressen"
 
-#: pretalx_public_voting/models.py:75
+#: local/pretalx-public-voting/pretalx_public_voting/models.py:75
 msgid ""
 "You can limit who is allowed to cast a vote. Please enter one email address "
 "per line."
@@ -181,41 +175,41 @@ msgstr ""
 "Du kannst beschränken, wer eine Bewertung abgeben darf. Bitte gib eine "
 "Adresse pro Zeile ein."
 
-#: pretalx_public_voting/models.py:79
+#: local/pretalx-public-voting/pretalx_public_voting/models.py:79
 msgid "Limit to tracks"
 msgstr ""
 
-#: pretalx_public_voting/models.py:83
+#: local/pretalx-public-voting/pretalx_public_voting/models.py:83
 msgid "Limit to session types"
 msgstr ""
 
-#: pretalx_public_voting/models.py:85
+#: local/pretalx-public-voting/pretalx_public_voting/models.py:85
 msgid "If no session type is selected, then all submissions are shown."
 msgstr ""
 
-#: pretalx_public_voting/models.py:97
-#: pretalx_public_voting/templates/pretalx_public_voting/submission_list.html:62
+#: local/pretalx-public-voting/pretalx_public_voting/models.py:97
+#: local/pretalx-public-voting/pretalx_public_voting/templates/pretalx_public_voting/submission_list.html:48
 msgid "Score"
 msgstr "Wertung"
 
-#: pretalx_public_voting/signals.py:14
-#: pretalx_public_voting/templates/pretalx_public_voting/submission_list.html:24
+#: local/pretalx-public-voting/pretalx_public_voting/signals.py:14
+#: local/pretalx-public-voting/pretalx_public_voting/templates/pretalx_public_voting/submission_list.html:23
 msgid "Public voting"
 msgstr "Öffentliche Abstimmung"
 
-#: pretalx_public_voting/templates/pretalx_public_voting/settings.html:8
+#: local/pretalx-public-voting/pretalx_public_voting/templates/pretalx_public_voting/settings.html:8
 msgid "Set up public voting"
 msgstr "Öffentliche Abstimmung einrichten"
 
-#: pretalx_public_voting/templates/pretalx_public_voting/settings.html:11
+#: local/pretalx-public-voting/pretalx_public_voting/templates/pretalx_public_voting/settings.html:11
 msgid "Download results CSV"
 msgstr ""
 
-#: pretalx_public_voting/templates/pretalx_public_voting/settings.html:14
+#: local/pretalx-public-voting/pretalx_public_voting/templates/pretalx_public_voting/settings.html:14
 msgid "Go to public voting"
 msgstr "Zur öffentlichen Abstimmung"
 
-#: pretalx_public_voting/templates/pretalx_public_voting/settings.html:19
+#: local/pretalx-public-voting/pretalx_public_voting/templates/pretalx_public_voting/settings.html:19
 msgid ""
 "Public voting will show your submissions publicly, and will allow anybody "
 "who provides a valid email address to vote. The email addresses are not "
@@ -225,11 +219,11 @@ msgstr ""
 "ermöglicht es jedem, der eine gültige E-Mail-Adresse hat, abzustimmen. E-"
 "Mail-Adressen werden nicht gespeichert. Die Abstimmung ist also anonym."
 
-#: pretalx_public_voting/templates/pretalx_public_voting/signup.html:6
+#: local/pretalx-public-voting/pretalx_public_voting/templates/pretalx_public_voting/signup.html:6
 msgid "Public voting signup"
 msgstr "Anmeldung zur öffentlichen Abstimmung"
 
-#: pretalx_public_voting/templates/pretalx_public_voting/signup.html:8
+#: local/pretalx-public-voting/pretalx_public_voting/templates/pretalx_public_voting/signup.html:8
 msgid ""
 "Welcome to the voting process for this event! Voting is open to the public, "
 "and we just need to confirm your email address first. You will only need to "
@@ -239,7 +233,7 @@ msgstr ""
 "Veranstaltung! Die Stimmabgabe steht jedem offen, wir brauchen nur deine E-"
 "Mail-Adresse."
 
-#: pretalx_public_voting/templates/pretalx_public_voting/signup.html:15
+#: local/pretalx-public-voting/pretalx_public_voting/templates/pretalx_public_voting/signup.html:15
 msgid ""
 "Please note that we do <strong>not</strong> store your email address, and "
 "all votes will be completely anonymous."
@@ -247,27 +241,15 @@ msgstr ""
 "Bitte beachte, dass wir deine E-Mail-Adresse <strong>nicht</strong> "
 "speichern und dass die Stimmabgabe vollständig anonym ist."
 
-#: pretalx_public_voting/templates/pretalx_public_voting/submission_list.html:29
-msgid "A filter is active. Only limited subset of all submission is shown."
-msgstr "Filter aktiv. Nur eine Auswahl an Abstimmungen werden angezeigt."
-
-#: pretalx_public_voting/templates/pretalx_public_voting/submission_list.html:30
-msgid "Click here to reset."
-msgstr "Klicke hier zum Zurücksetzten."
-
-#: pretalx_public_voting/templates/pretalx_public_voting/submission_list.html:41
+#: local/pretalx-public-voting/pretalx_public_voting/templates/pretalx_public_voting/submission_list.html:32
 msgid "This talk's header image"
 msgstr "Das Titelbild des Vortags"
 
-#: pretalx_public_voting/templates/pretalx_public_voting/submission_list.html:47
-msgid "Copied!"
-msgstr "Kopiert!"
-
-#: pretalx_public_voting/templates/pretalx_public_voting/submission_list.html:80
+#: local/pretalx-public-voting/pretalx_public_voting/templates/pretalx_public_voting/submission_list.html:66
 msgid "Save!"
 msgstr "Speichern!"
 
-#: pretalx_public_voting/templates/pretalx_public_voting/submission_list.html:86
+#: local/pretalx-public-voting/pretalx_public_voting/templates/pretalx_public_voting/submission_list.html:72
 msgid ""
 "This page is invalid. Please double-check that you have followed a complete "
 "link to this place."
@@ -275,15 +257,15 @@ msgstr ""
 "Diese Seite ist nicht zulässig. Bitte vergewissere dich, dass du den "
 "gesamten Link verwendet hast."
 
-#: pretalx_public_voting/templates/pretalx_public_voting/submission_list.html:89
+#: local/pretalx-public-voting/pretalx_public_voting/templates/pretalx_public_voting/submission_list.html:75
 msgid "Click here to sign up for voting."
 msgstr "Bitte klicke hier, um dich für die öffentliche Abstimmung anzumelden."
 
-#: pretalx_public_voting/templates/pretalx_public_voting/thanks.html:5
+#: local/pretalx-public-voting/pretalx_public_voting/templates/pretalx_public_voting/thanks.html:5
 msgid "Thanks for signing up!"
 msgstr "Vielen Dank für deine Anmeldung!"
 
-#: pretalx_public_voting/templates/pretalx_public_voting/thanks.html:7
+#: local/pretalx-public-voting/pretalx_public_voting/templates/pretalx_public_voting/thanks.html:7
 msgid ""
 "Thanks for signing up for public voting. You've received an email with your "
 "personal link to the vote. If you don't see an email within five minutes, "
@@ -297,6 +279,11 @@ msgstr ""
 #: local/pretalx-public-voting/pretalx_public_voting/views.py:148
 msgid "Thank you for your vote!"
 msgstr "Vielen Dank für deine Stimmabgabe!"
+
+#, python-brace-format
+#~ msgid "Please assign a score between {self.min_value} and {self.max_value}!"
+#~ msgstr ""
+#~ "Bitte wähle eine Wertung zwischen {self.min_value} und {self.max_value}!"
 
 #~ msgid "Save"
 #~ msgstr "Speichern"

--- a/pretalx_public_voting/static/pretalx_public_voting/share.js
+++ b/pretalx_public_voting/static/pretalx_public_voting/share.js
@@ -1,16 +1,15 @@
 document.addEventListener('DOMContentLoaded', () => {
   const shareButtons = document.querySelectorAll("a[data-pretalx-voting-selector='share']")
-  const linkAttributeName = "data-pretalx-voting-share-url"
   const successTextAttributeName = "data-pretalx-voting-copied-successful-text"
 
   shareButtons.forEach((button) => {
     const resetHTML = button.innerHTML; // Ensures that original text is always restored even if button is pressed multiple times.
     button.addEventListener('click', async (event) => {
       event.preventDefault();
-      const path = button.attributes.getNamedItem(linkAttributeName).value;
-      const successText = button.attributes.getNamedItem(successTextAttributeName).value;
-      if (path === null) return console.error('Share button clicked but no URL found.', { button });
-      const link = window.location.origin + path;
+      const votingPath = button.getAttribute("href");
+      const successText = button.getAttribute(successTextAttributeName);
+      if (votingPath === null) return console.error('Share button clicked but no URL found.', { button });
+      const link = window.location.origin + votingPath;
       navigator.clipboard.writeText(link)
         .then(() =>  button.textContent = successText ?? 'Copied!') // Falling back to english translation just in case.
         .catch((error) => console.error('Failed to copy url to clipboard', { link, error, button }))

--- a/pretalx_public_voting/static/pretalx_public_voting/share.js
+++ b/pretalx_public_voting/static/pretalx_public_voting/share.js
@@ -1,0 +1,20 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const shareButtons = document.querySelectorAll("a[data-pretalx-voting-selector='share']")
+  const linkAttributeName = "data-pretalx-voting-share-url"
+  const successTextAttributeName = "data-pretalx-voting-copied-successful-text"
+
+  shareButtons.forEach((button) => {
+    const resetHTML = button.innerHTML; // Ensures that original text is always restored even if button is pressed multiple times.
+    button.addEventListener('click', async (event) => {
+      event.preventDefault();
+      const path = button.attributes.getNamedItem(linkAttributeName).value;
+      const successText = button.attributes.getNamedItem(successTextAttributeName).value;
+      if (path === null) return console.error('Share button clicked but no URL found.', { button });
+      const link = window.location.origin + path;
+      navigator.clipboard.writeText(link)
+        .then(() =>  button.textContent = successText ?? 'Copied!') // Falling back to english translation just in case.
+        .catch((error) => console.error('Failed to copy url to clipboard', { link, error, button }))
+        .finally(() => setTimeout(() => button.innerHTML = resetHTML, 3000));
+    })
+  })
+})

--- a/pretalx_public_voting/static/pretalx_public_voting/vote.css
+++ b/pretalx_public_voting/static/pretalx_public_voting/vote.css
@@ -1,3 +1,8 @@
+.header {
+  display: flex;
+  justify-content: space-between;
+}
+
 .submission-card {
   margin-top: 18px;
 }

--- a/pretalx_public_voting/static/pretalx_public_voting/vote.css
+++ b/pretalx_public_voting/static/pretalx_public_voting/vote.css
@@ -1,4 +1,4 @@
-.header {
+.public-voting-header {
   display: flex;
   justify-content: space-between;
 }

--- a/pretalx_public_voting/templates/pretalx_public_voting/submission_list.html
+++ b/pretalx_public_voting/templates/pretalx_public_voting/submission_list.html
@@ -44,7 +44,7 @@
                     <div class="card-body">
                         <div class="header">
                             <h3 class="card-title">{{ submission.title }}</h3>
-                            <a href="#" data-pretalx-voting-selector="share" data-pretalx-voting-share-url="{% url 'plugins:pretalx_public_voting:signup' event=request.event.slug %}?sid={{ submission.id }}" class="btn btn-link" data-pretalx-voting-copied-successful-text="{% trans 'Copied!' %}">
+                            <a href="#" data-pretalx-voting-selector="share" data-pretalx-voting-share-url="{% url 'plugins:pretalx_public_voting:signup' event=request.event.slug %}?submission_code={{ submission.code }}" class="btn btn-link" data-pretalx-voting-copied-successful-text="{% trans 'Copied!' %}">
                                 <i class="fa fa-link" aria-hidden="true"></i>
                             </a>
                         </div>

--- a/pretalx_public_voting/templates/pretalx_public_voting/submission_list.html
+++ b/pretalx_public_voting/templates/pretalx_public_voting/submission_list.html
@@ -9,6 +9,7 @@
     {% compress js %}
         <script src="{% static "js/jquery.js" %}"></script>
         <script src="{% static "pretalx_public_voting/vote.js" %}"></script>
+        <script src="{% static "pretalx_public_voting/share.js" %}"></script>
     {% endcompress %}
 {% endblock %}
 
@@ -22,6 +23,14 @@
 {% block content %}
     <h1>{% trans "Public voting" %}</h1>
     {{ request.event.public_vote_settings.text|rich_text }}
+
+    {% if filter_active %}
+        <p class="alert alert-info">
+            {% trans "A filter is active. Only limited subset of all submission is shown." %}
+            <a href="{{ remove_filter_url }}">{% trans "Click here to reset." %}</a>
+        </p>
+    {% endif %}
+
     {% if hashed_email %}
         <form method="POST">
             {% csrf_token %}
@@ -33,7 +42,12 @@
                         </div>
                     {% endif %}
                     <div class="card-body">
-                        <h3 class="card-title">{{ submission.title }}</h3>
+                        <div class="header">
+                            <h3 class="card-title">{{ submission.title }}</h3>
+                            <a href="#" data-pretalx-voting-selector="share" data-pretalx-voting-share-url="{% url 'plugins:pretalx_public_voting:signup' event=request.event.slug %}?sid={{ submission.id }}" class="btn btn-link" data-pretalx-voting-copied-successful-text="{% trans 'Copied!' %}">
+                                <i class="fa fa-link" aria-hidden="true"></i>
+                            </a>
+                        </div>
                         {% if not request.event.public_vote_settings.anonymize_speakers %}
                             <p class="card-subtitle mb-2 text-muted">{{ submission.display_speaker_names }}</p>
                         {% endif %}

--- a/pretalx_public_voting/templates/pretalx_public_voting/submission_list.html
+++ b/pretalx_public_voting/templates/pretalx_public_voting/submission_list.html
@@ -42,7 +42,7 @@
                         </div>
                     {% endif %}
                     <div class="card-body">
-                        <div class="header">
+                        <div class="public-voting-header">
                             <h3 class="card-title">{{ submission.title }}</h3>
                             <a href="{% url 'plugins:pretalx_public_voting:signup' event=request.event.slug %}?submission_code={{ submission.code }}" data-pretalx-voting-selector="share" class="btn btn-link" data-pretalx-voting-copied-successful-text="{% trans 'Copied!' %}">
                                 <i class="fa fa-link" aria-hidden="true"></i>

--- a/pretalx_public_voting/templates/pretalx_public_voting/submission_list.html
+++ b/pretalx_public_voting/templates/pretalx_public_voting/submission_list.html
@@ -44,7 +44,7 @@
                     <div class="card-body">
                         <div class="header">
                             <h3 class="card-title">{{ submission.title }}</h3>
-                            <a href="#" data-pretalx-voting-selector="share" data-pretalx-voting-share-url="{% url 'plugins:pretalx_public_voting:signup' event=request.event.slug %}?submission_code={{ submission.code }}" class="btn btn-link" data-pretalx-voting-copied-successful-text="{% trans 'Copied!' %}">
+                            <a href="{% url 'plugins:pretalx_public_voting:signup' event=request.event.slug %}?submission_code={{ submission.code }}" data-pretalx-voting-selector="share" class="btn btn-link" data-pretalx-voting-copied-successful-text="{% trans 'Copied!' %}">
                                 <i class="fa fa-link" aria-hidden="true"></i>
                             </a>
                         </div>

--- a/pretalx_public_voting/views.py
+++ b/pretalx_public_voting/views.py
@@ -48,7 +48,7 @@ class SignupView(PublicVotingRequired, FormView):
     def get_form_kwargs(self):
         result = super().get_form_kwargs()
         result["event"] = self.request.event
-        result["sid"] = self.request.GET.get("sid")
+        result["submission_code"] = self.request.GET.get("submission_code")
         return result
 
     def form_valid(self, form):
@@ -86,10 +86,10 @@ class SubmissionListView(PublicVotingRequired, ListView):
             state=SubmissionStates.SUBMITTED
         )
 
-        # Filter by 'sid' query parameter if provided
-        sid = self.request.GET.get("sid")
-        if sid:
-            base_qs = base_qs.filter(pk=sid)
+        # Filter by 'submission_code' query parameter if provided
+        submission_code = self.request.GET.get("submission_code")
+        if submission_code:
+            base_qs = base_qs.filter(code=submission_code) # TODO! Change filter to use code!
 
         tracks = self.request.event.public_vote_settings.limit_tracks.all()
         if tracks:
@@ -131,8 +131,8 @@ class SubmissionListView(PublicVotingRequired, ListView):
 
     def get_context_data(self, **kwargs):
         result = super().get_context_data(**kwargs)
-        sid = self.request.GET.get("sid")
-        if sid:
+        submission_code = self.request.GET.get("submission_code")
+        if submission_code:
             result["filter_active"] = True
             result["remove_filter_url"] = self.request.path
         else:

--- a/pretalx_public_voting/views.py
+++ b/pretalx_public_voting/views.py
@@ -89,7 +89,7 @@ class SubmissionListView(PublicVotingRequired, ListView):
         # Filter by 'submission_code' query parameter if provided
         submission_code = self.request.GET.get("submission_code")
         if submission_code:
-            base_qs = base_qs.filter(code=submission_code) # TODO! Change filter to use code!
+            base_qs = base_qs.filter(code=submission_code)
 
         tracks = self.request.event.public_vote_settings.limit_tracks.all()
         if tracks:


### PR DESCRIPTION
Hi,

during our public voting phase, we got often a feature request by the presenters, asking for an option to get a dedicated voting link for their submission, that could be included in some mail, social media post etc.

I am not a Django developer myself, more a Node.js person, so I am open for any feedback or improvements :)

Best regards